### PR TITLE
Resets need for subdomain

### DIFF
--- a/components/CommunityHome.tsx
+++ b/components/CommunityHome.tsx
@@ -1,6 +1,6 @@
 import Router from "next/router";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { v4 } from "uuid";
 import { useAccount } from "wagmi";
 import { useLazyQuery, useQuery } from "@apollo/client";
@@ -11,8 +11,6 @@ import IdeaRow from "@/components/IdeaRow";
 import EmptyState from "@/components/EmptyState";
 import FAQAccordion from "@/components/FAQAccordion";
 import CommunityHomeLiveDataBoard from "@/components/CommunityHomeLiveDataBoard";
-import { Community } from "@prisma/client";
-import { SUPPORTED_SUBDOMAINS } from "@/utils/supportedTokenUtils";
 import { getPropLot } from "@/graphql/types/__generated__/getPropLot";
 import Link from "next/link";
 import { virtualTagColorMap } from "@/utils/virtualTagColors";
@@ -69,11 +67,7 @@ const TagButtons = ({ tags }: { tags: getTags_tags[] }) => (
   </div>
 );
 
-export default function CommunityHome({
-  community,
-}: {
-  community: Community & { data: { name: string; pfpUrl: string } };
-}) {
+export default function CommunityHome() {
   const { address } = useAccount();
 
   const { data: tagsResponse } = useQuery<getTags>(GET_TAGS, {
@@ -98,7 +92,7 @@ export default function CommunityHome({
     DELEGATED_VOTES_BY_OWNER_SUB,
     {
       context: {
-        clientName: community?.uname as SUPPORTED_SUBDOMAINS,
+        clientName: "nouns",
       },
     }
   );
@@ -206,9 +200,7 @@ export default function CommunityHome({
           </button>
         </div>
       </section>
-
-      <CommunityHomeLiveDataBoard community={community} />
-
+      <CommunityHomeLiveDataBoard />
       <section className="!font-ptRootUI flex flex-1 justify-center px-[20px] xl:px-0 py-[72px] gap-8">
         <FAQAccordion />
       </section>

--- a/components/CommunityHomeLiveDataBoard.tsx
+++ b/components/CommunityHomeLiveDataBoard.tsx
@@ -8,12 +8,8 @@ import { StandaloneNounCircular } from "./NounCircular";
 import { BigNumber } from "ethers";
 import useHomeLiveData from "@/hooks/useHomeLiveData";
 
-const CommunityHomeLiveDataBoard = ({
-  community,
-}: {
-  community: Community;
-}) => {
-  const liveData = useHomeLiveData(community.uname);
+const CommunityHomeLiveDataBoard = () => {
+  const liveData = useHomeLiveData("nouns");
 
   return (
     <section className="flex flex-1 flex-col gap-lg max-w-screen-xl mx-auto px-lg mt-xl w-full">
@@ -62,7 +58,7 @@ const CommunityHomeLiveDataBoard = ({
               </div>
             </div>
           </div>
-          {liveData?.previousAuctions?.map((auction: any, idx) => {
+          {liveData?.previousAuctions?.map((auction: any, idx: number) => {
             return (
               <div
                 key={auction.id}
@@ -84,7 +80,9 @@ const CommunityHomeLiveDataBoard = ({
                   />
                 </Link>
                 <div className="rounded-lg flex-col justify-start items-start inline-flex">
-                  <div className="text-black text-base font-bold">Noun {auction.noun?.id}</div>
+                  <div className="text-black text-base font-bold">
+                    Noun {auction.noun?.id}
+                  </div>
                   <div className="justify-start items-start gap-2 inline-flex">
                     <div className="opacity-50 text-black text-base font-bold">
                       Sold for
@@ -104,8 +102,8 @@ const CommunityHomeLiveDataBoard = ({
           <div className="flex-wrap grow shrink self-stretch justify-start items-start gap-lg inline-flex">
             <div className="min-w-[350px] max-h-[300px] flex-1 self-stretch p-md bg-white justify-center rounded-xl border border-slate flex-col justify-start items-start gap-lg inline-flex">
               <div className="xl:max-w-[300px] self-stretch text-lg font-bold">
-                Ξ{formatEthValue(liveData?.balance || 0)} treasury
-                to fund your projects and ideas
+                Ξ{formatEthValue(liveData?.balance || 0)} treasury to fund your
+                projects and ideas
               </div>
               <div className="flex-1 self-stretch p-md bg-[#FFC925] rounded-2xl border border-black justify-center items-center gap-lg inline-flex">
                 <div className="w-20 h-20 relative">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,51 +1,7 @@
-import LandingPage from "@/components/LandingPage";
 import CommunityHome from "@/components/CommunityHome";
-import { GetServerSidePropsContext } from "next";
-import { Community } from "@prisma/client";
-import prisma from "@/lib/prisma";
-import getCommunityByDomain from "@/utils/communityByDomain";
 
-export const DEFAULT_HOMEPAGE_MATCH = "__NONE__";
-
-const Home = ({
-  communityName,
-  community,
-}: {
-  communityName: string;
-  community: Community & { data: { name: string; pfpUrl: string } };
-}) => {
-  if (communityName === DEFAULT_HOMEPAGE_MATCH) {
-    return <LandingPage />;
-  }
-
-  return <CommunityHome community={community} />;
+const Home = () => {
+  return <CommunityHome />;
 };
 
 export default Home;
-
-export async function getServerSideProps(context: GetServerSidePropsContext) {
-  let community;
-  const { communityDomain } = getCommunityByDomain(context.req);
-
-  if (communityDomain) {
-    community = await prisma.community.findFirst({
-      where: {
-        uname: communityDomain,
-      },
-    });
-  }
-
-  // If there isn't a community then redirect to the landing page
-  const communityName = !community ? DEFAULT_HOMEPAGE_MATCH : communityDomain;
-
-  // 1. communityDomain and no community = __NONE__ show placeholder
-  // 2. communityDomain and community = correct community to show
-  // 3. communityDomain but no community = there was a subdomain, but it doesn't exist (probably can't happen)
-
-  return {
-    props: {
-      communityName,
-      community: community ? JSON.parse(JSON.stringify(community)) : null,
-    },
-  };
-}


### PR DESCRIPTION
No need to support many subdomains anymore because we are giving lil nouns the proplot domain. This should simplify our code a bit. At this point I think our best bet is getting this out for nouns (since they funded us) and worry about other DAOs who might be interested in us (builder) by creating a light SDK. This way, our platform doesn't need to support many subdomains and many communities which will make some of the platform code easier to write.