### PR TITLE
Th/update candidate code

### DIFF
--- a/graphql/resolvers/CandidateResolvers.ts
+++ b/graphql/resolvers/CandidateResolvers.ts
@@ -17,6 +17,7 @@ const resolvers: IResolvers = {
       const candidate = await CandidateService.createCandidate({
         slug: args.options.slug,
         ideaId: args.options.ideaId,
+        proposer: context.authScope.user.wallet,
       });
       return candidate;
     },

--- a/graphql/resolvers/CandidateResolvers.ts
+++ b/graphql/resolvers/CandidateResolvers.ts
@@ -17,7 +17,7 @@ const resolvers: IResolvers = {
       const candidate = await CandidateService.createCandidate({
         slug: args.options.slug,
         ideaId: args.options.ideaId,
-        proposer: context.authScope.user.wallet,
+        proposerId: context.authScope.user.wallet,
       });
       return candidate;
     },

--- a/graphql/subgraph/index.ts
+++ b/graphql/subgraph/index.ts
@@ -110,3 +110,63 @@ export const GET_GOVERNANCE_DATA = gql`
   }
 }
 `
+
+export const GET_CANDIDATE_DATA = gql`
+query getCandidateData($candidateId: ID!) {
+  proposalCandidate(id: $candidateId) {
+    id
+    slug
+    proposer
+    lastUpdatedTimestamp
+    createdTransactionHash
+    canceled
+    versions {
+      content {
+        title
+      }
+    }
+    latestVersion {
+      content {
+        title
+        description
+        targets
+        values
+        signatures
+        calldatas
+        encodedProposalHash
+        proposalIdToUpdate
+        contentSignatures {
+          id
+          signer {
+            id
+            proposals {
+              id
+            }
+          }
+          sig
+          expirationTimestamp
+          canceled
+          reason
+        }
+      }
+    }
+  }
+}
+`
+
+export const GET_CANDIDATE_VOTES = gql`
+query getCandidateVotes($candidateId: ID!) {
+  candidateFeedbacks(where: {candidate_: {id: $candidateId}}) {
+    supportDetailed
+    votes
+    reason
+    createdTimestamp
+    voter {
+      id
+    }
+    candidate {
+      id
+    }
+  }
+}
+`;

--- a/lib/apollo.ts
+++ b/lib/apollo.ts
@@ -11,7 +11,7 @@ const defaultLink = new HttpLink({
 });
 
 const nounsDAOLink = new HttpLink({
-  uri: 'https://api.goldsky.com/api/public/project_cldf2o9pqagp43svvbk5u3kmo/subgraphs/nouns/0.1.0/gn',
+  uri: 'https://api.goldsky.com/api/public/project_cldf2o9pqagp43svvbk5u3kmo/subgraphs/nouns/prod/gn',
 });
 
 const lilNounsDAOLink = new HttpLink({

--- a/lib/apollo.ts
+++ b/lib/apollo.ts
@@ -14,22 +14,14 @@ const nounsDAOLink = new HttpLink({
   uri: 'https://api.goldsky.com/api/public/project_cldf2o9pqagp43svvbk5u3kmo/subgraphs/nouns/prod/gn',
 });
 
-const lilNounsDAOLink = new HttpLink({
-  uri: 'https://api.thegraph.com/subgraphs/name/lilnounsdao/lil-nouns-subgraph',
-});
-
 //pass them to apollo-client config
 export const client = new ApolloClient({
   ssrMode: typeof window === 'undefined',
   credentials: 'include',
   link: ApolloLink.split(
     operation => operation.getContext().clientName === SUPPORTED_SUBDOMAINS.NOUNS,
-    nounsDAOLink, //if above
-    ApolloLink.split(
-      operation => operation.getContext().clientName === SUPPORTED_SUBDOMAINS.LIL_NOUNS,
-      lilNounsDAOLink,
-      defaultLink,
-    ),
+    nounsDAOLink,
+    defaultLink,
   ),
   cache: new InMemoryCache(),
 });

--- a/prisma/migrations/20231011195106_add_proposer_to_candidate/migration.sql
+++ b/prisma/migrations/20231011195106_add_proposer_to_candidate/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `proposerId` to the `Candidate` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Candidate" ADD COLUMN     "proposerId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Candidate" ADD CONSTRAINT "Candidate_proposerId_fkey" FOREIGN KEY ("proposerId") REFERENCES "User"("wallet") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,8 @@ model Candidate {
   slug                  String    @unique
   ideaId                String
   idea                  Idea      @relation(fields: [ideaId], references: [id], onDelete: Cascade)
+  proposerId            String
+  proposer              User      @relation(fields: [proposerId], references: [wallet], onDelete: Cascade)
 }
 
 model Idea {
@@ -73,6 +75,7 @@ model User {
   ideas             Idea[]
   votes             Vote[]
   comments          Comment[]
+  candidates        Candidate[]
 }
 
 // direction

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -61,6 +61,31 @@ async function seed() {
     });
   }
 
+  user.wallet = "0x0658f4ed17289144717713adffc2539ef7c2ef8e"
+  await prisma.user.create({ data: user });
+
+  const ideaWithCandidate = await prisma.idea.create({
+    data: {
+      communityId: community.id,
+      title: chance.word({ length: 5 }),
+      tldr: chance.sentence({ words: 5 }),
+      description: chance.sentence({ words: 10 }),
+      creatorId: `0x0658f4ed17289144717713adffc2539ef7c2ef8e`,
+      tokenSupplyOnCreate: 50,
+      createdAtBlock: 16534162,
+      expiryDate: moment(new Date()).add(7, "days").toDate(),
+      expiryOption: "SEVEN_DAYS"
+    },
+  });
+
+  await prisma.candidate.create({
+    data: {
+      ideaId: ideaWithCandidate.id,
+      slug: "bring-a-million-shredders-onchain",
+      proposerId: '0x0658f4ed17289144717713adffc2539ef7c2ef8e',
+    },
+  });
+
   for (let i = 0; i < 20; i++) {
     user.wallet = `0xcf7ed3acca5a467e9e704c703e8d87f634fb0f${
       i < 10 ? `c${i}` : i

--- a/services/candidates.ts
+++ b/services/candidates.ts
@@ -8,7 +8,7 @@ AWS.config.update({
 });
 
 class CandidateService {
-  static async createCandidate(data: { slug: string; ideaId: string; proposer: string; }) {
+  static async createCandidate(data: { slug: string; ideaId: string; proposerId: string; }) {
     try {
       if (!data.slug || !data.ideaId) {
         throw new Error("Failed to save idea: missing slug or ideaId");
@@ -18,7 +18,7 @@ class CandidateService {
         data: {
           slug: data.slug,
           ideaId: data.ideaId,
-          proposerId: proposer,
+          proposerId: data.proposerId,
         },
       });
 

--- a/services/candidates.ts
+++ b/services/candidates.ts
@@ -8,7 +8,7 @@ AWS.config.update({
 });
 
 class CandidateService {
-  static async createCandidate(data: { slug: string; ideaId: string }) {
+  static async createCandidate(data: { slug: string; ideaId: string; proposer: string; }) {
     try {
       if (!data.slug || !data.ideaId) {
         throw new Error("Failed to save idea: missing slug or ideaId");
@@ -18,6 +18,7 @@ class CandidateService {
         data: {
           slug: data.slug,
           ideaId: data.ideaId,
+          proposerId: proposer,
         },
       });
 

--- a/utils/communityByDomain.tsx
+++ b/utils/communityByDomain.tsx
@@ -12,7 +12,7 @@ const getCommunityByDomain = (req: any) => {
     : host?.match(/(.*)\.proplot\.wtf/);
 
   const communityDomain =
-    subdomain?.[1]?.toLowerCase() || (isDev && cdHeader?.toLowerCase()) || "";
+    subdomain?.[1]?.toLowerCase() || (isDev && cdHeader?.toLowerCase()) || "nouns";
   const supportedTokenConfig =
     SupportedTokenGetterMap[communityDomain as SUPPORTED_SUBDOMAINS];
 

--- a/utils/supportedTokenUtils.ts
+++ b/utils/supportedTokenUtils.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import { DELEGATED_VOTES_BY_OWNER_SUB, DELEGATED_VOTES_BY_OWNER_SUB_AT_BLOCK, GET_CURRENT_AUCTION, GET_PREVIOUS_AUCTIONS, GET_RECENT_PROPOSALS, TOTAL_NOUNS_CREATED, GET_GOVERNANCE_DATA } from '@/graphql/subgraph'
+import { DELEGATED_VOTES_BY_OWNER_SUB, DELEGATED_VOTES_BY_OWNER_SUB_AT_BLOCK, GET_CURRENT_AUCTION, GET_PREVIOUS_AUCTIONS, GET_RECENT_PROPOSALS, TOTAL_NOUNS_CREATED, GET_GOVERNANCE_DATA, GET_CANDIDATE_DATA, GET_CANDIDATE_VOTES } from '@/graphql/subgraph'
 import { nounsGraphqlClient, lilNounsGraphqlClient } from '@/graphql/clients/nouns-graphql-client'
 
 // Extend this with subdomains for other DAOs that we want to integrate.
@@ -131,5 +131,21 @@ export const SupportedTokenGetterMap = {
         throw new Error('Failed to fetch governance data from subgraph')
       }
     },
+    getCandidateData: async (candidateId: string) => {
+      try {
+        const data: any = await nounsGraphqlClient.query(GET_CANDIDATE_DATA, { candidateId }).toPromise()
+        return data?.data?.proposalCandidate
+      } catch(e) {
+        throw new Error('Failed to fetch candidate data from subgraph')
+      }
+    },
+    getCandidateVotes: async (candidateId: string) => {
+      try {
+        const data: any = await nounsGraphqlClient.query(GET_CANDIDATE_VOTES, { candidateId }).toPromise()
+        return data?.data?.candidateFeedbacks
+      } catch(e) {
+        throw new Error('Failed to fetch candidate vote data from subgraph')
+      }
+    }
   }
 }

--- a/utils/supportedTokenUtils.ts
+++ b/utils/supportedTokenUtils.ts
@@ -5,72 +5,10 @@ import { nounsGraphqlClient, lilNounsGraphqlClient } from '@/graphql/clients/nou
 
 // Extend this with subdomains for other DAOs that we want to integrate.
 export enum SUPPORTED_SUBDOMAINS {
-  LIL_NOUNS = 'lilnouns',
   NOUNS = 'nouns'
 }
 
 export const SupportedTokenGetterMap = {
-  [SUPPORTED_SUBDOMAINS.LIL_NOUNS]: {
-    account: "",
-    getUserTokenCount: async (address: string) => {
-      try {
-        const data: any = await lilNounsGraphqlClient.query(DELEGATED_VOTES_BY_OWNER_SUB, { id: address.toLowerCase() }).toPromise()
-        return parseInt(data?.data?.delegate?.delegatedVotes) || 0
-      } catch(e) {
-        throw new Error('Failed to fetch token count from subgraph')
-      }
-    },
-    getTotalSupply: async () => {
-      try {
-        const data: any = await lilNounsGraphqlClient.query(TOTAL_NOUNS_CREATED, {}).toPromise()
-        return parseInt(data?.data?.governance?.delegatedVotes) || undefined
-      } catch(e) {
-        throw new Error('Failed to fetch token supply from subgraph')
-      }
-    },
-    getUserVoteWeightAtBlock: async (address: string, blockNumber: number) => {
-      try {
-        const data: any = await lilNounsGraphqlClient.query(DELEGATED_VOTES_BY_OWNER_SUB_AT_BLOCK, { id: address.toLowerCase(), block: { number: blockNumber } }).toPromise()
-        return parseInt(data?.data?.delegate?.delegatedVotes) || 0
-      } catch(e) {
-        throw new Error('Failed to fetch token count from subgraph')
-      }
-    },
-    getCurrentAuction: async () => {
-      try {
-        const data: any = await lilNounsGraphqlClient.query(GET_CURRENT_AUCTION, {}).toPromise()
-        return data?.data?.auctions?.[0]
-      } catch(e) {
-        throw new Error('Failed to fetch current auction from subgraph')
-      }
-    },
-    getPreviousAuctions: async (nounIds: number[]) => {
-      try {
-        const data: any = await lilNounsGraphqlClient.query(GET_PREVIOUS_AUCTIONS, { nounIds }).toPromise()
-        return data?.data?.auctions
-      } catch(e) {
-        throw new Error('Failed to fetch current auction from subgraph')
-      }
-    },
-    getRecentProposals: async () => {
-      try {
-        const sixWeeksAgo = moment().subtract(6, 'weeks');
-        const recentTimestamp = sixWeeksAgo.unix();
-        const data: any = await lilNounsGraphqlClient.query(GET_RECENT_PROPOSALS, { recentTimestamp }).toPromise()
-        return data?.data?.proposals
-      } catch(e) {
-        throw new Error('Failed to fetch recent proposals from subgraph')
-      }
-    },
-    getGovernanceData: async () => {
-      try {
-        const data: any = await lilNounsGraphqlClient.query(GET_GOVERNANCE_DATA, { }).toPromise()
-        return data?.data?.governance
-      } catch(e) {
-        throw new Error('Failed to fetch governance data from subgraph')
-      }
-    },
-  },
   [SUPPORTED_SUBDOMAINS.NOUNS]: {
     account: "0x0bc3807ec262cb779b38d65b38158acc3bfede10",
     getUserTokenCount: async (address: string) => {


### PR DESCRIPTION
Moving the subgraph queries for candidate proposals into the supportedTokenUtil which contains functions for all the other subgraph queries.

Adding a proposerId to the Candidate model as we need to query for candidates proposals by `proposerId-slug`. Not sure if this was an oversight or you had a work around for it already @frog.
